### PR TITLE
update spec to fail/pass for the right reason

### DIFF
--- a/models/dose_spec.rb
+++ b/models/dose_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe "Dose", :type => :model do
   end
 
   it "description cannot be blank" do
-    dose = Dose.new(description: "")
+    dose = Dose.new(description: "", ingredient: lemon, cocktail: mojito)
     expect(dose).not_to be_valid
   end
 


### PR DESCRIPTION
Dose description presence test passed, even if it was because the coscktail or ingredient was missing. So test would pass even if the `validates :description, presence: true` was not present in the `Dose` model